### PR TITLE
Add simple python flashcard example

### DIFF
--- a/flashcard_project/README.md
+++ b/flashcard_project/README.md
@@ -1,0 +1,23 @@
+# Flashcard Project
+
+This is a simple command line flashcard quiz implemented in Python.
+
+## Requirements
+
+Python 3.7 or later is recommended. No external dependencies are required.
+
+## Usage
+
+1. Prepare a `flashcards.json` file containing an array of question and answer pairs (see the included example).
+2. Run the quiz:
+
+```bash
+python flashcard.py
+```
+
+You can also specify a different JSON file:
+
+```bash
+python flashcard.py path/to/your_cards.json
+```
+

--- a/flashcard_project/flashcard.py
+++ b/flashcard_project/flashcard.py
@@ -1,0 +1,38 @@
+import json
+import sys
+from dataclasses import dataclass
+from typing import List
+
+@dataclass
+class FlashCard:
+    question: str
+    answer: str
+
+
+def load_flashcards(path: str) -> List[FlashCard]:
+    with open(path, 'r', encoding='utf-8') as f:
+        data = json.load(f)
+    return [FlashCard(**item) for item in data]
+
+
+def run_quiz(cards: List[FlashCard]) -> None:
+    score = 0
+    for idx, card in enumerate(cards, start=1):
+        print(f"Question {idx}: {card.question}")
+        user_answer = input("Your answer: ").strip()
+        if user_answer.lower() == card.answer.lower():
+            print("Correct!\n")
+            score += 1
+        else:
+            print(f"Incorrect. The answer is: {card.answer}\n")
+    print(f"You got {score}/{len(cards)} correct.")
+
+
+def main(argv: List[str]) -> None:
+    path = argv[1] if len(argv) > 1 else 'flashcards.json'
+    cards = load_flashcards(path)
+    run_quiz(cards)
+
+
+if __name__ == '__main__':
+    main(sys.argv)

--- a/flashcard_project/flashcards.json
+++ b/flashcard_project/flashcards.json
@@ -1,0 +1,5 @@
+[
+    {"question": "What is the capital of France?", "answer": "Paris"},
+    {"question": "What is 2 + 2?", "answer": "4"},
+    {"question": "What color is the sky?", "answer": "Blue"}
+]


### PR DESCRIPTION
## Summary
- add a basic flashcard quiz
- include example questions in JSON
- document how to use the flashcard app

## Testing
- `python3 -m py_compile flashcard_project/flashcard.py`

------
https://chatgpt.com/codex/tasks/task_e_6863d73b5414832099d851575807ea7e