### PR TITLE
Add particle scatter simulation webpage

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Particle Scatter Simulation</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <canvas id="canvas"></canvas>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,128 @@
+const canvas = document.getElementById('canvas');
+const ctx = canvas.getContext('2d');
+
+function resize() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+window.addEventListener('resize', resize);
+resize();
+
+const gravity = 0.3;
+const blocks = [];
+const particles = [];
+
+class Block {
+  constructor(x, y, squareSize, gridSize, mass) {
+    this.x = x;
+    this.y = y;
+    this.squareSize = squareSize;
+    this.gridSize = gridSize;
+    this.mass = mass;
+    this.vy = 0;
+    this.color = `hsl(${(mass / 6) * 360},70%,60%)`;
+  }
+
+  update() {
+    this.vy += gravity;
+    this.y += this.vy;
+    const bottom = canvas.height - this.gridSize * this.squareSize;
+    if (this.y >= bottom) {
+      this.y = bottom;
+      this.scatter();
+    }
+  }
+
+  draw() {
+    ctx.fillStyle = this.color;
+    for (let i = 0; i < this.gridSize; i++) {
+      for (let j = 0; j < this.gridSize; j++) {
+        ctx.fillRect(
+          this.x + i * this.squareSize,
+          this.y + j * this.squareSize,
+          this.squareSize,
+          this.squareSize
+        );
+      }
+    }
+  }
+
+  scatter() {
+    const speed = 6 / this.mass;
+    for (let i = 0; i < this.gridSize; i++) {
+      for (let j = 0; j < this.gridSize; j++) {
+        const px = this.x + i * this.squareSize;
+        const py = this.y + j * this.squareSize;
+        const vx = (Math.random() - 0.5) * speed * 2;
+        const vy = -Math.random() * speed;
+        particles.push(
+          new Particle(px, py, vx, vy, this.squareSize, this.color)
+        );
+      }
+    }
+    const idx = blocks.indexOf(this);
+    if (idx > -1) {
+      blocks.splice(idx, 1);
+    }
+  }
+}
+
+class Particle {
+  constructor(x, y, vx, vy, size, color) {
+    this.x = x;
+    this.y = y;
+    this.vx = vx;
+    this.vy = vy;
+    this.size = size;
+    this.color = color;
+  }
+
+  update() {
+    this.vy += gravity;
+    this.x += this.vx;
+    this.y += this.vy;
+
+    if (this.y + this.size > canvas.height) {
+      this.y = canvas.height - this.size;
+      this.vy *= -0.5;
+      this.vx *= 0.8;
+    }
+  }
+
+  draw() {
+    ctx.fillStyle = this.color;
+    ctx.fillRect(this.x, this.y, this.size, this.size);
+  }
+}
+
+function spawnBlock(x) {
+  const grid = 5;
+  const size = 12;
+  const mass = 2 + Math.random() * 4; // 2-6
+  if (x === undefined) {
+    x = Math.random() * (canvas.width - grid * size);
+  } else {
+    x = Math.min(Math.max(0, x - (grid * size) / 2), canvas.width - grid * size);
+  }
+  blocks.push(new Block(x, -grid * size, size, grid, mass));
+}
+
+canvas.addEventListener('click', (e) => {
+  spawnBlock(e.clientX);
+});
+
+function animate() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  blocks.forEach((b) => {
+    b.update();
+    b.draw();
+  });
+  particles.forEach((p) => {
+    p.update();
+    p.draw();
+  });
+  requestAnimationFrame(animate);
+}
+
+spawnBlock();
+animate();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,17 @@
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+body {
+  background: linear-gradient(135deg, #1e3c72, #2a5298);
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+}


### PR DESCRIPTION
## Summary
- Add index.html linking CSS and JS for canvas simulation
- Create stylish CSS with gradient background
- Implement particle physics and mass-based scattering in script.js

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68966e45d6648320b9e792d1b2ed21cd